### PR TITLE
Properly support async instance creation

### DIFF
--- a/api.go
+++ b/api.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 )
 
 type Response struct {
@@ -76,7 +75,7 @@ func CreateInstance(p martini.Params, req *http.Request, r render.Render, broker
 	// Get the correct database logic depending on the type of plan. (shared vs dedicated)
 	adapter, _ := s.InitializeAdapter(plan, brokerDb)
 
-	shared := reflect.TypeOf(adapter) != reflect.TypeOf(&(DedicatedDBAdapter{}))
+	shared := plan.Adapter == AdapterShared
 
 	acceptsIncomplete := false
 	if req.URL.Query().Get("accepts_incomplete") == "true" {

--- a/api.go
+++ b/api.go
@@ -8,9 +8,15 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 )
 
 type Response struct {
+	Description string `json:"description"`
+}
+
+type ErrorResponse struct {
+	Error string `json:"error"`
 	Description string `json:"description"`
 }
 
@@ -70,6 +76,19 @@ func CreateInstance(p martini.Params, req *http.Request, r render.Render, broker
 	// Get the correct database logic depending on the type of plan. (shared vs dedicated)
 	adapter, _ := s.InitializeAdapter(plan, brokerDb)
 
+	shared := reflect.TypeOf(adapter) != reflect.TypeOf(&(DedicatedDBAdapter{}))
+
+	acceptsIncomplete := false
+	if req.URL.Query().Get("accepts_incomplete") == "true" {
+		acceptsIncomplete = true
+	}
+
+	if !shared && !acceptsIncomplete {
+		// UNPROCESSABLE_ENTITY
+		r.JSON(422, ErrorResponse{Error: "AsyncRequired", Description: "This service plan requires client support for asynchronous service operations." })
+		return
+	}
+
 	err := instance.Init(
 		p["id"],
 		sr.OrganizationGuid,
@@ -108,7 +127,26 @@ func CreateInstance(p martini.Params, req *http.Request, r render.Render, broker
 	}
 	brokerDb.Save(&instance)
 
-	r.JSON(http.StatusCreated, Response{"The instance was created"})
+	if shared {
+		r.JSON(http.StatusCreated, Response{"The instance was created"})
+	} else {
+		r.JSON(http.StatusAccepted, Response{"The instance is being created asynchronously"})
+	}
+}
+
+func LastOperationInstance(p martini.Params, req *http.Request, r render.Render, brokerDb *gorm.DB, s *Settings, catalog *Catalog) {
+	instance := Instance{}
+
+	brokerDb.Where("uuid = ?", p["id"]).First(&instance)
+
+	if instance.Id <= 0 {
+		r.JSON(http.StatusNotFound, Response{"Requested instance id cannot be found"})
+		return
+	}
+	plan := catalog.fetchPlan(instance.ServiceId, instance.PlanId)
+	adapter, _ := s.InitializeAdapter(plan, brokerDb)
+	status, _ := adapter.GetDBStatus(&instance)
+	r.JSON(http.StatusOK, status)
 }
 
 // BindInstance
@@ -124,7 +162,7 @@ func BindInstance(p martini.Params, r render.Render, brokerDb *gorm.DB, s *Setti
 
 	brokerDb.Where("uuid = ?", p["instance_id"]).First(&instance)
 	if instance.Id == 0 {
-		r.JSON(404, Response{"Instance not found"})
+		r.JSON(http.StatusNotFound, Response{"Instance not found"})
 		return
 	}
 	password, err := instance.GetPassword(s.EncryptionKey)

--- a/main.go
+++ b/main.go
@@ -58,6 +58,8 @@ func App(settings *Settings, DB *gorm.DB) *martini.ClassicMartini {
 
 	// Create the service instance (cf create-service-instance)
 	m.Put("/v2/service_instances/:id", CreateInstance)
+	// Last operation state used by async service instance creation
+	m.Get("/v2/service_instances/:id/last_operation", LastOperationInstance)
 
 	// Bind the service to app (cf bind-service)
 	m.Put("/v2/service_instances/:instance_id/service_bindings/:id", BindInstance)

--- a/rds.go
+++ b/rds.go
@@ -22,14 +22,22 @@ const (
 	InstanceNotGone                           // 4
 )
 
-type DatabaseStatus struct {
-	State        string       `json:"state"`
-	Description  string       `json:"description"`
+type InstanceCreationState string
+
+const (
+	InstanceCreationSucceeded InstanceCreationState = "succeeded"
+	InstanceCreationFailed InstanceCreationState = "failed"
+	InstanceCreationInProgress InstanceCreationState = "in progress"
+)
+
+type InstanceStatus struct {
+	State       InstanceCreationState	`json:"state"`
+	Description string			`json:"description"`
 }
 
 type DBAdapter interface {
 	CreateDB(i *Instance, password string) (DBInstanceState, error)
-	GetDBStatus(i *Instance) (DatabaseStatus, error)
+	GetDBStatus(i *Instance) (InstanceStatus, error)
 	BindDBToApp(i *Instance, password string) (map[string]string, error)
 	DeleteDB(i *Instance) (DBInstanceState, error)
 }
@@ -46,9 +54,9 @@ func (d *MockDBAdapter) CreateDB(i *Instance, password string) (DBInstanceState,
 	return InstanceReady, nil
 }
 
-func (d *MockDBAdapter) GetDBStatus(i *Instance) (DatabaseStatus, error) {
+func (d *MockDBAdapter) GetDBStatus(i *Instance) (InstanceStatus, error) {
 	// TODO
-	return DatabaseStatus{}, nil
+	return InstanceStatus{}, nil
 }
 
 func (d *MockDBAdapter) BindDBToApp(i *Instance, password string) (map[string]string, error) {
@@ -82,14 +90,15 @@ func (d *SharedDBAdapter) CreateDB(i *Instance, password string) (DBInstanceStat
 	return InstanceReady, nil
 }
 
-func (d *SharedDBAdapter) GetDBStatus(i *Instance) (DatabaseStatus, error) {
+func (d *SharedDBAdapter) GetDBStatus(i *Instance) (InstanceStatus, error) {
 	rows, err := d.SharedDbConn.DB().Query(fmt.Sprintf("SELECT datname FROM pg_database WHERE datname='%s';", i.Database))
-	result := DatabaseStatus{}
+	defer rows.Close()
+	result := InstanceStatus{}
 	if rows.Next() {
-		result.State = "succeeded"
+		result.State = InstanceCreationSucceeded
 		result.Description = "Creation completed"
 	} else {
-		result.State = "failed"
+		result.State = InstanceCreationFailed
 		result.Description = "Unknown"
 	}
 	return result, err
@@ -162,28 +171,27 @@ func (d *DedicatedDBAdapter) CreateDB(i *Instance, password string) (DBInstanceS
 	}
 }
 
-func (d *DedicatedDBAdapter) GetDBStatus(i *Instance) (DatabaseStatus, error) {
-	svc := rds.New(&aws.Config{Region: "eu-west-1"})
+func (d *DedicatedDBAdapter) GetDBStatus(i *Instance) (InstanceStatus, error) {
+	svc := rds.New(&aws.Config{Region: i.AwsRegion})
 	request := &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: &i.Database,
 	}
 	result, err := svc.DescribeDBInstances(request)
-	status := DatabaseStatus{
-		State: "in progress",
-		Description: "Failed to retrieve state",
+	instanceCount := len(result.DBInstances)
+	status := InstanceStatus{
+		State: InstanceCreationInProgress,
+		Description: fmt.Sprintf("Failed to retrieve state, %d instances found", instanceCount),
 	}
-	if yes := d.DidAwsCallSucceed(err); yes && len(result.DBInstances) > 0 {
+	if yes := d.DidAwsCallSucceed(err); yes && instanceCount == 1 {
 		databaseInstance := result.DBInstances[0]
+		status.Description = "AWS status: " + *(databaseInstance.DBInstanceStatus)
 		switch *(databaseInstance.DBInstanceStatus) {
-		case "failed":
-		case "incompatible-parameters":
-			status.State = "failed"
-			status.Description = "Failed to create instance"
+		case "failed", "incompatible-parameters":
+			status.State = InstanceCreationFailed
 		case "available":
-			status.State = "succeeded"
-			status.Description = "Instance is ready"
+			status.State = InstanceCreationSucceeded
 		default:
-			status.Description = *(databaseInstance.DBInstanceStatus)
+			status.State = InstanceCreationInProgress
 		}
 	}
 	return status, err

--- a/settings.go
+++ b/settings.go
@@ -10,6 +10,11 @@ import (
 	"strconv"
 )
 
+const (
+	AdapterShared string = "shared"
+	AdapterDedicated string = "dedicated"
+)
+
 type Settings struct {
 	EncryptionKey string
 	DbConfig      *DBConfig
@@ -31,11 +36,11 @@ func (s Settings) InitializeAdapter(plan *Plan,
 	}
 
 	switch plan.Adapter {
-	case "shared":
+	case AdapterShared:
 		dbAdapter = &SharedDBAdapter{
 			SharedDbConn: sharedDbConn,
 		}
-	case "dedicated":
+	case AdapterDedicated:
 		dbAdapter = &DedicatedDBAdapter{
 			InstanceType: plan.InstanceType,
 		}


### PR DESCRIPTION
Main change:
- asynchronous instead of synchronous integration with service brokers in cases where an RDS DB Instance needs to be created ([see here](http://docs.cloudfoundry.org/services/api.html#asynchronous-operations))

![async-service-broker-flow.png](http://docs.cloudfoundry.org/services/images/async-service-broker-flow.png)